### PR TITLE
avoid stack overflow from power_on calling hard_reset

### DIFF
--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -448,6 +448,7 @@ where
             self.network.at_tx.reset()?;
             if self.power_on().is_err() {
                 self.hard_reset()?;
+                self.power_on()?;
             }
 
             self.power_state = PowerState::On;
@@ -612,6 +613,7 @@ where
             // as well as consecutive AT timeouts and do a hard reset.
             Err(crate::network::Error::Generic(GenericError::Timeout)) => {
                 self.hard_reset()?;
+                self.power_on()?;
                 Err(Error::Generic(GenericError::Timeout))
             }
             result => result.map_err(Error::from),


### PR DESCRIPTION
power_on was calling hard_reset which called power_on again. This caused the stack overflow we saw for the last months.

I removed the call to power_on from hard_reset and also removed the reset_calls from power_on. Instead I placed those calls explicitely where needed. 

I tested this on Niro100 and it still seems to connect as it did before. So it think it will not make things any worse.