### PR TITLE
Stabilize connection

### DIFF
--- a/ublox-cellular/src/client.rs
+++ b/ublox-cellular/src/client.rs
@@ -613,7 +613,6 @@ where
             // as well as consecutive AT timeouts and do a hard reset.
             Err(crate::network::Error::Generic(GenericError::Timeout)) => {
                 self.hard_reset()?;
-                self.power_on()?;
                 Err(Error::Generic(GenericError::Timeout))
             }
             result => result.map_err(Error::from),

--- a/ublox-cellular/src/network.rs
+++ b/ublox-cellular/src/network.rs
@@ -25,7 +25,7 @@ use hash32_derive::Hash32;
 use serde::{Deserialize, Serialize};
 
 const REGISTRATION_CHECK_INTERVAL: SecsDurationU32 = SecsDurationU32::secs(15);
-const REGISTRATION_TIMEOUT: MinutesDurationU32 = MinutesDurationU32::minutes(3);
+const REGISTRATION_TIMEOUT: MinutesDurationU32 = MinutesDurationU32::minutes(5);
 const CHECK_IMSI_TIMEOUT: MinutesDurationU32 = MinutesDurationU32::minutes(1);
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
Removed unnecessary power_on as after a reset because of a timeout.  `hard_reset` will set `power_state`  to `PowerState::Off` and the code in `initialize` will take care of sending a `power_on` if necessary. 

Changed `REGISTRATION_TIMEOUT` to 5min to give the modem more time to search for a network. 